### PR TITLE
Not possible to include js files referenced by relative path in test files

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -19,12 +19,10 @@ var path = require('path'),
         getPaths = function(opt) {
             var g = glob.sync(opt, {
                 cwd: process.cwd()
-            }).map(function (filepath) {
-                return path.join(process.cwd(), filepath);
             });
             if (g && g.length) {
-                options.paths = [].concat(options.paths, g);
-            }
+                options.paths = g;
+            }  
         };
 
         while (args.length > 0) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -15,7 +15,7 @@ var path = require('path'),
             run: true,
             quiet: false,
             exitOnFail: false
-        }, newPath, paths, a, p, t, v, concurrent,
+        }, newPath, paths, a, p, t, v, concurrent, globPattern,
         getPaths = function(opt) {
             var g = glob.sync(opt, {
                 cwd: process.cwd()
@@ -92,6 +92,10 @@ var path = require('path'),
                         throw('-p requires an argument');
                     }
                     break;
+                case "-g":
+                    globPattern = args.shift();
+                    getPaths(globPattern);
+                    break;
                 case "-f":
                 case "--fail":
                     options.exitOnFail = true;
@@ -122,6 +126,7 @@ var path = require('path'),
                     console.log('           as the list of files to process.');
                     console.log('   -p, --prefix <string> String to prefix to all urls (for dynamic server names)');
                     console.log('   -S, --suffix <string> String to add to the end of all urls (for dynamic server names)');
+                    console.log('   -g  retrieve yui test files by a specified glob pattern');
                     console.log('   -o, --outfile <path to export file>');
                     console.log('       You can specify an export type with the following:');
                     console.log('       --tap TAP export (default)');

--- a/lib/options.js
+++ b/lib/options.js
@@ -21,8 +21,8 @@ var path = require('path'),
                 cwd: process.cwd()
             });
             if (g && g.length) {
-                options.paths = g;
-            }  
+                options.paths = options.paths.concat(g);
+            }
         };
 
         while (args.length > 0) {


### PR DESCRIPTION
Returning absolute paths broke the ability to include js files
referenced by relative path in test files
