### PR TITLE
Add --phantom option to allow non-PATH phantomjs binary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Commandline Arguments
            --junit JUnit XML export
        --server Starts a static file server in the CWD, tests should be relative to this directory
        --port <Number> The port to start the server on
+       --phantom <path to phantomjs executable> A non-PATH location for the phantomjs executable
        --no-run Do not execute the tests, just prep the server (for other testing)
 
     Coverage Options

--- a/lib/grover.js
+++ b/lib/grover.js
@@ -11,7 +11,7 @@ var exec = require('child_process').exec,
 exports.init = function(options, callback) {
     options = options || {};
     options.paths = options.paths || [];
-    exports.check(function(version) {
+    exports.check(options, function(version) {
         if (!version) {
             log.error('Please install the phantomjs binary in your path!');
             util.exit(1);
@@ -36,8 +36,12 @@ exports.init = function(options, callback) {
     });
 };
 
-exports.check = function(callback) {
-    exec('phantomjs --version', function(stdin, stdout) {
+exports.check = function(options, callback) {
+    if (typeof options === 'function') {
+        callback = options;
+        options = null;
+    }
+    exec((options && options.phantom || 'phantomjs') + ' --version', function(stdin, stdout) {
         var version = stdout.replace('\n', '');
         callback(version);
     });
@@ -80,7 +84,7 @@ exports.test = function(options, file, callback) {
     if (options.timeout) {
         args.push(options.timeout);
     }
-    child = spawn('phantomjs', args);
+    child = spawn(options.phantom || 'phantomjs', args);
     child.stdout.on('data', function(data) {
         stdout += data;
     });

--- a/lib/options.js
+++ b/lib/options.js
@@ -8,6 +8,7 @@ var path = require('path'),
         var options = {
             color: true,
             port: 7000,
+            phantom: 'phantomjs', // relies on PATH
             coverageWarn: 80,
             concurrent: 15,
             paths: [],
@@ -20,6 +21,7 @@ var path = require('path'),
             sourceFilePrefix: false,
             coverageFileName: false
         }, newPath, paths, a, p, t, v, concurrent, coverageFileName, sourceFilePrefix,
+        phantom,
         getPaths = function(opt) {
             if (process.platform === 'win32' && !options.suffix) { //If options.suffix it's probably URL
                 var g = glob.sync(opt, {
@@ -93,6 +95,27 @@ var path = require('path'),
                         options.port = p;
                     } else {
                         args.unshift(a);
+                    }
+                    break;
+                case "--phantom":
+                    phantom = args.shift();
+                    if (phantom) {
+                        // allows "path/to/bin/" and "path/to/bin/phantomjs"
+                        phantom = /phantomjs$/.test(phantom)
+                            ? phantom
+                            : path.join(phantom, 'phantomjs');
+
+                        // always make it an absolute path
+                        phantom = path.resolve(phantom);
+
+                        // make extra sure that the binary exists
+                        if (util.existsSync(phantom)) {
+                            options.phantom = phantom;
+                        } else {
+                            throw "Custom phantomjs binary could not be found!";
+                        }
+                    } else {
+                        throw "--phantom requires a path";
                     }
                     break;
                 case "-t":
@@ -171,6 +194,7 @@ var path = require('path'),
                     log.log('       --junit JUnit XML export');
                     log.log('   --server Starts a static file server in the CWD, tests should be relative to this directory');
                     log.log('   --port <Number> The port to start the server on');
+                    log.log('   --phantom <path to phantomjs executable> A non-PATH location for the phantomjs executable');
                     log.log('   --no-run Do not execute the tests, just prep the server (for other testing)');
                     log.log('   --no-color Force no terminal colors');
                     log.log('');

--- a/tests/args.js
+++ b/tests/args.js
@@ -436,6 +436,54 @@ var tests = {
             assert.equal(topic.outtype, 'TAP');
         }
     },
+    '--phantom (default)': {
+        topic: function () {
+            return parse([]);
+        },
+        'should default phantom executable to use PATH': function (topic) {
+            assert.equal(topic.phantom, 'phantomjs');
+        }
+    },
+    '--phantom (empty)': {
+        topic: function () {
+            return parse(['--phantom']);
+        },
+        'should require an argument if option passed': function (topic) {
+            assert.equal(topic, '--phantom requires a path');
+        }
+    },
+    '--phantom (bad path)': {
+        topic: function () {
+            return parse(['--phantom', path.join(__dirname, '../tests/missing/phantomjs')]);
+        },
+        'should reject path when executable not found': function (topic) {
+            assert.equal(topic, 'Custom phantomjs binary could not be found!');
+        }
+    },
+    '--phantom path/to/bin': {
+        topic: function () {
+            return parse(['--phantom', './tests/build/bin']);
+        },
+        'should add phantomjs executable to customized phantom path': function (topic) {
+            assert.equal(topic.phantom, path.join(__dirname, '../tests/build/bin/phantomjs'));
+        }
+    },
+    '--phantom path/to/bin/phantomjs': {
+        topic: function () {
+            return parse(['--phantom', './tests/build/bin/phantomjs']);
+        },
+        'should accept full path to custom phantomjs location': function (topic) {
+            assert.equal(topic.phantom, path.join(__dirname, '../tests/build/bin/phantomjs'));
+        }
+    },
+    '--phantom /absolute/path/to/bin/phantomjs': {
+        topic: function () {
+            return parse(['--phantom', path.join(__dirname, '../tests/build/bin/phantomjs')]);
+        },
+        'should accept absolute phantom path & executable': function (topic) {
+            assert.equal(topic.phantom, path.join(__dirname, '../tests/build/bin/phantomjs'));
+        }
+    },
     '--help': {
         topic: function() {
             var self = this,

--- a/tests/build/bin/phantomjs
+++ b/tests/build/bin/phantomjs
@@ -1,0 +1,1 @@
+This is not the actual binary, just present for an fs.existsSync in --phantom arg parsing tests.

--- a/tests/grover.js
+++ b/tests/grover.js
@@ -94,7 +94,7 @@ var tests = {
                 });
             };
 
-            grover.check = function(callback) {
+            grover.check = function(options, callback) {
                 callback(null);
             };
             grover.init({}, function() {


### PR DESCRIPTION
We found ourselves trying to run `grover` in an environment (Jenkins) that was supremely hostile to dynamically augmenting the `PATH` inside an Ant target. Unlike the `npm` workaround of just calling `/full/path/to/node /full/path/to/npm/script <args>`, we found ourselves employing dastardly shell script hacks that make me cringe.

Enter `--phantom`! If you don't pass the option, the current behaviour is preserved. As I did not want to encumber the project with many megabytes of cross-platform binaries to test, I merely made the argument check extremely conservative about the actual filesystem presence of the option's argument.
