### PR TITLE
jshint tests/*.js

### DIFF
--- a/lib/grover.js
+++ b/lib/grover.js
@@ -93,6 +93,7 @@ exports.test = function(options, file, callback) {
 exports.dispatch = function(options, callback) {
     var stack = new Stack(),
         testResults = [],
+        i,
         noop = function() {},
         run = function(cb) {
             var file = options.paths.shift();

--- a/tests/args.js
+++ b/tests/args.js
@@ -509,9 +509,9 @@ var tests = {
     'getPaths': {
         'good files': {
             topic: function() {
-                var _platform = process.platform;
+                var _platform = process.platform, ret;
                 process.platform = 'win32';
-                var ret = parse(['./tests/html/*.html']);
+                ret = parse(['./tests/html/*.html']);
                 process.platform = _platform;
                 return ret;
             },
@@ -521,9 +521,9 @@ var tests = {
         },
         'no files': {
             topic: function() {
-                var _platform = process.platform;
+                var _platform = process.platform, ret;
                 process.platform = 'win32';
-                var ret = parse(['./tests/html/*.php']);
+                ret = parse(['./tests/html/*.php']);
                 process.platform = _platform;
                 return ret;
             },
@@ -534,4 +534,5 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('arguments').addBatch(tests).export(module);

--- a/tests/coverage.js
+++ b/tests/coverage.js
@@ -1,3 +1,4 @@
+/*jshint multistr: true */
 var vows = require('vows'),
     assert = require('assert'),
     fs = require('fs'),
@@ -145,7 +146,7 @@ var tests = {
                     s: {},
                     fnMap: {}
                 });
-                return cover.coverageInfo
+                return cover.coverageInfo;
             },
             'and should be ok': function(topic) {
                 assert.ok(topic);
@@ -162,7 +163,7 @@ var tests = {
                         s: {},
                         fnMap: {}
                     });
-                    return cover.coverageInfo
+                    return cover.coverageInfo;
                 },
                 'and should be ok': function(topic) {
                     assert.ok(topic);
@@ -189,7 +190,7 @@ var tests = {
                     { foo: 'bar' },
                     { path: 'b/c.js' },
                     { path: 'a/a.js' },
-                    { path: 'a/c.js' },
+                    { path: 'a/c.js' }
                 ];
                 return items.sort(topic);
             },
@@ -205,4 +206,5 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('coverage').addBatch(tests).export(module);

--- a/tests/general.js
+++ b/tests/general.js
@@ -30,8 +30,8 @@ var tests = {
     },
     'log.error should not exit': {
         topic: function() {
-            var util = require('../lib/index');
-            var _exit = util.exit;
+            var util = require('../lib/index'),
+                _exit = util.exit;
             util.exit = function() {
                 assert.ok(false);
             };
@@ -46,10 +46,10 @@ var tests = {
     },
     'test color with no terminal': {
         topic: function() {
-            var isTTY = process.stdout.isTTY;
+            var isTTY = process.stdout.isTTY, out;
             process.stdout.isTTY = false;
             util.init({ color: false });
-            var out = util.color('foo', 'red');
+            out = util.color('foo', 'red');
             process.stdout.isTTY = isTTY;
             return out;
         },
@@ -98,7 +98,7 @@ var tests = {
     },
     'test canPrint': {
         topic: function() {
-            return require('../lib').canPrint
+            return require('../lib').canPrint;
         },
         'should be a function': function(topic) {
             assert.isFunction(topic);
@@ -185,4 +185,5 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('general').addBatch(tests).export(module);

--- a/tests/grover.js
+++ b/tests/grover.js
@@ -1,3 +1,4 @@
+/*jshint unused: false */
 var vows = require('vows'),
     assert = require('assert'),
     path = require('path'),
@@ -312,7 +313,8 @@ var tests = {
             assert.ok(topic);
             assert.isUndefined(topic.results);
         }
-    },
+    }
 };
 
+/*jshint es5: true */
 vows.describe('grover').addBatch(tests).export(module);

--- a/tests/istanbul.js
+++ b/tests/istanbul.js
@@ -1,3 +1,4 @@
+/*jshint unused: false */
 var vows = require('vows'),
     assert = require('assert'),
     fs = require('fs'),
@@ -76,17 +77,17 @@ var tests = {
             },
             'and should have report dirs': {
                 topic: function() {
-                    return fs.readdirSync(report)
+                    return fs.readdirSync(report);
                 },
                 'should have index.html': function(topic) {
                     var hasIndex = topic.some(function(file) {
-                        return file === 'index.html'
+                        return file === 'index.html';
                     });
                     assert.isTrue(hasIndex);
                 },
                 'should have yql/': function(topic) {
                     var hasIndex = topic.some(function(file) {
-                        return file === 'yql'
+                        return file === 'yql';
                     });
                     assert.isTrue(hasIndex);
                 }
@@ -95,4 +96,5 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('istanbul').addBatch(tests).export(module);

--- a/tests/message.js
+++ b/tests/message.js
@@ -81,5 +81,6 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('process.message').addBatch(tests).export(module);
 

--- a/tests/process.js
+++ b/tests/process.js
@@ -69,5 +69,6 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('process SIGINT').addBatch(tests).export(module);
 

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,3 +1,4 @@
+/*jshint unused: false */
 var vows = require('vows'),
     assert = require('assert'),
     path = require('path'),
@@ -112,7 +113,7 @@ var tests = {
                     port: 7001,
                     silent: true,
                     run: true
-                }, this.callback);
+                }, self.callback);
 
             },
             'and should have server listening': {
@@ -125,7 +126,7 @@ var tests = {
                         cont.emit('server2');
                         self.callback(null, res.statusCode);
 
-                        try{ topic.close(); } catch (e) {};
+                        try{ topic.close(); } catch (e) {}
                     });
                 },
                 'should serve a 404 as the default': function(topic) {
@@ -149,7 +150,7 @@ var tests = {
                             run: false
                         }, function(e, server) {
                             util.exit = _exit;
-                            try{ server.close(); } catch (e) {};
+                            try{ server.close(); } catch (e) {}
                             self.callback(null, {
                                 error: e,
                                 code: code
@@ -163,6 +164,7 @@ var tests = {
                 }
             }
         },
+        /* This was a duplicate key, and never run. When made unique, it causes the suite to stall.
         'should error when started on port 80': {
             topic: function() {
                 var self = this,
@@ -181,7 +183,7 @@ var tests = {
                     run: true
                 }, function(e, server) {
                     util.exit = _exit;
-                    try{ server.close(); } catch (e) {};
+                    try{ server.close(); } catch (e) {}
                     self.callback(null, {
                         error: e,
                         code: code
@@ -193,6 +195,7 @@ var tests = {
                 assert.ok(topic.error);
             }
         },
+        */
         'should error when started on port 80': {
             topic: function() {
                 var self = this,
@@ -225,7 +228,7 @@ var tests = {
                 }, {
                     code: 'Fake Error',
                     toString: function() {
-                        return 'Fake Error'
+                        return 'Fake Error';
                     }
                 }));
             },
@@ -241,7 +244,7 @@ var tests = {
                 }, {
                     code: 'EADDRINUSE',
                     toString: function() {
-                        return 'EADDRINUSE'
+                        return 'EADDRINUSE';
                     }
                 }));
             },
@@ -253,5 +256,6 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('server').addBatch(tests).export(module);
 

--- a/tests/yuitest.js
+++ b/tests/yuitest.js
@@ -1,3 +1,4 @@
+/*jshint unused: false */
 var vows = require('vows'),
     assert = require('assert'),
     fs = require('fs'),
@@ -28,7 +29,7 @@ var vows = require('vows'),
 var tests = {
     'should execute a good test with yuitest': {
         topic: function() {
-            var self = this;
+            var self = this,
                 _exit = util.exit;
             util.exit = function() {};
             runTest('./html/yuitest.html', function(err, json) {
@@ -47,7 +48,7 @@ var tests = {
         },
         'and with coverage warn': {
             topic: function() {
-                var self = this;
+                var self = this,
                     _exit = util.exit;
                 util.exit = function() {};
                 process.chdir(__dirname);
@@ -59,7 +60,7 @@ var tests = {
                     '--silent',
                     '--outfile',
                     path.join(__dirname, 'out/json.info'),
-                    '--json',
+                    '--json'
                 ], function(err, json) {
                     util.exit = _exit;
                     self.callback(err, json);
@@ -80,7 +81,7 @@ var tests = {
             },
             'and with invalid sourceFilePrefix': {
                 topic: function() {
-                    var self = this;
+                    var self = this,
                         _exit = util.exit;
                     util.exit = function() {};
                     process.chdir(__dirname);
@@ -108,4 +109,5 @@ var tests = {
     }
 };
 
+/*jshint es5: true */
 vows.describe('yuitest').addBatch(tests).export(module);


### PR DESCRIPTION
During my `--phantom` test-writing, I started seeing some odd typos and minor errors when linting files in my editor (the key combo is almost a reflex, by now). This "fixes" them, with advisory comments where necessary. (Gotta love `vows` using the reserved word `export` as a method name)

The behaviour of the tests is unchanged, nor did I add `tests/*.js` to the `pretest` script.

``` bash
jshint --config node_modules/yui-lint/jshint.json tests/*.js
```

This is absurdly low-priority, go enjoy your holiday already. :)
