### PR TITLE
Save the JSON coverage object when --coverdir specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 coverage
 tests/out/*.info
 tests/report/
+tests/report2/

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ npm-debug.log
 coverage
 tests/out/*.info
 tests/report/
-tests/report2/

--- a/lib/coverage.js
+++ b/lib/coverage.js
@@ -401,6 +401,9 @@ var writeIstanbulReport = function(options) {
     var collect = new istanbul.Collector(),
         report = istanbul.Report.create('lcov', {
             dir: options.coverdir
+        }),
+        jsonReport = istanbul.Report.create('json', {
+            dir: options.coverdir
         });
     
     coverageInfo.forEach(function(coverage) {
@@ -409,6 +412,7 @@ var writeIstanbulReport = function(options) {
     
     log.log('generating istanbul LCOV report, saving here: ' + options.coverdir);
     report.writeReport(collect, true);
+    jsonReport.writeReport(collect, true);
 };
 
 var save = function(options) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "yuitest": "*",
         "cli-table": "*",
         "echoecho": "~0.1.2",
-        "istanbul": "~0.1.10",
+        "istanbul": "~0.1.42",
         "express": "~2.5.0",
         "glob": "~3.1.12",
         "timethat": "~0.0.1",

--- a/tests/5-istanbul.js
+++ b/tests/5-istanbul.js
@@ -9,6 +9,7 @@ var vows = require('vows'),
     grover = require('../lib/grover'),
     rimraf = require('rimraf'),
     report = path.join(__dirname, 'report'),
+    report2 = path.join(__dirname, 'report2'),
     runTest = function(file, timeout, cb) {
         if (!cb) {
             cb = timeout;
@@ -28,10 +29,12 @@ var vows = require('vows'),
         });
     };
 
-function cleanReportDir() {
-    if (exists(report)) {
-        rimraf.sync(report);
-    }
+if (exists(report)) {
+    rimraf.sync(report);
+}
+
+if (exists(report2)) {
+    rimraf.sync(report2);
 }
 
 var tests = {
@@ -40,7 +43,6 @@ var tests = {
             var self = this,
                 _exit = util.exit;
             util.exit = function() {};
-            cleanReportDir();
             runTest('./html/istanbul.html', function(err, json) {
                 util.exit = _exit;
                 self.callback(err, json);
@@ -60,7 +62,6 @@ var tests = {
                 var self = this,
                     _exit = util.exit;
                 util.exit = function() {};
-                cleanReportDir();
                 process.chdir(__dirname);
                 runTest('./html/istanbul.html', [
                     '--istanbul-report',
@@ -102,11 +103,10 @@ var tests = {
                 var self = this,
                     _exit = util.exit;
                 util.exit = function() {};
-                cleanReportDir();
                 process.chdir(__dirname);
                 runTest('./html/istanbul.html', [
                     '--coverdir',
-                    report
+                    report2
                 ],function(err, json) {
                     util.exit = _exit;
                     self.callback(err, json);
@@ -123,7 +123,7 @@ var tests = {
             },
             'and should have report dirs': {
                 topic: function() {
-                    return fs.readdirSync(report);
+                    return fs.readdirSync(report2);
                 },
                 'should have lcov.info': function (topic) {
                     var hasIndex = topic.some(function(file) {

--- a/tests/5-istanbul.js
+++ b/tests/5-istanbul.js
@@ -28,8 +28,10 @@ var vows = require('vows'),
         });
     };
 
-if (exists(report)) {
-    rimraf.sync(report);
+function cleanReportDir() {
+    if (exists(report)) {
+        rimraf.sync(report);
+    }
 }
 
 var tests = {
@@ -38,6 +40,7 @@ var tests = {
             var self = this,
                 _exit = util.exit;
             util.exit = function() {};
+            cleanReportDir();
             runTest('./html/istanbul.html', function(err, json) {
                 util.exit = _exit;
                 self.callback(err, json);
@@ -57,6 +60,7 @@ var tests = {
                 var self = this,
                     _exit = util.exit;
                 util.exit = function() {};
+                cleanReportDir();
                 process.chdir(__dirname);
                 runTest('./html/istanbul.html', [
                     '--istanbul-report',
@@ -88,6 +92,54 @@ var tests = {
                 'should have yql/': function(topic) {
                     var hasIndex = topic.some(function(file) {
                         return file === 'yql';
+                    });
+                    assert.isTrue(hasIndex);
+                }
+            }
+        },
+        'and should execute yet another good test with output like istanbul cover': {
+            topic: function() {
+                var self = this,
+                    _exit = util.exit;
+                util.exit = function() {};
+                cleanReportDir();
+                process.chdir(__dirname);
+                runTest('./html/istanbul.html', [
+                    '--coverdir',
+                    report
+                ],function(err, json) {
+                    util.exit = _exit;
+                    self.callback(err, json);
+                });
+            },
+            'and have suite name': function(json) {
+                assert.equal(json.name, 'YQL');
+            },
+            'and should have 8 passing tests': function(json) {
+                assert.equal(json.passed, 8);
+            },
+            'and should have 0 failed tests': function(json) {
+                assert.equal(json.failed, 0);
+            },
+            'and should have report dirs': {
+                topic: function() {
+                    return fs.readdirSync(report);
+                },
+                'should have lcov.info': function (topic) {
+                    var hasIndex = topic.some(function(file) {
+                        return file === 'lcov.info';
+                    });
+                    assert.isTrue(hasIndex);
+                },
+                'should have lcov-report': function (topic) {
+                    var hasIndex = topic.some(function(file) {
+                        return file === 'lcov-report';
+                    });
+                    assert.isTrue(hasIndex);
+                },
+                'should have coverage json': function(topic) {
+                    var hasIndex = topic.some(function(file) {
+                        return file === 'coverage-final.json';
                     });
                     assert.isTrue(hasIndex);
                 }

--- a/tests/5-istanbul.js
+++ b/tests/5-istanbul.js
@@ -9,7 +9,6 @@ var vows = require('vows'),
     grover = require('../lib/grover'),
     rimraf = require('rimraf'),
     report = path.join(__dirname, 'report'),
-    report2 = path.join(__dirname, 'report2'),
     runTest = function(file, timeout, cb) {
         if (!cb) {
             cb = timeout;
@@ -29,12 +28,10 @@ var vows = require('vows'),
         });
     };
 
-if (exists(report)) {
-    rimraf.sync(report);
-}
-
-if (exists(report2)) {
-    rimraf.sync(report2);
+function cleanReportDir() {
+    if (exists(report)) {
+        rimraf.sync(report);
+    }
 }
 
 var tests = {
@@ -43,6 +40,7 @@ var tests = {
             var self = this,
                 _exit = util.exit;
             util.exit = function() {};
+            cleanReportDir();
             runTest('./html/istanbul.html', function(err, json) {
                 util.exit = _exit;
                 self.callback(err, json);
@@ -63,6 +61,7 @@ var tests = {
                     _exit = util.exit;
                 util.exit = function() {};
                 process.chdir(__dirname);
+                cleanReportDir();
                 runTest('./html/istanbul.html', [
                     '--istanbul-report',
                     report
@@ -96,52 +95,53 @@ var tests = {
                     });
                     assert.isTrue(hasIndex);
                 }
-            }
-        },
-        'and should execute yet another good test with output like istanbul cover': {
-            topic: function() {
-                var self = this,
-                    _exit = util.exit;
-                util.exit = function() {};
-                process.chdir(__dirname);
-                runTest('./html/istanbul.html', [
-                    '--coverdir',
-                    report2
-                ],function(err, json) {
-                    util.exit = _exit;
-                    self.callback(err, json);
-                });
             },
-            'and have suite name': function(json) {
-                assert.equal(json.name, 'YQL');
-            },
-            'and should have 8 passing tests': function(json) {
-                assert.equal(json.passed, 8);
-            },
-            'and should have 0 failed tests': function(json) {
-                assert.equal(json.failed, 0);
-            },
-            'and should have report dirs': {
+            'and should execute yet another good test with output like istanbul cover': {
                 topic: function() {
-                    return fs.readdirSync(report2);
-                },
-                'should have lcov.info': function (topic) {
-                    var hasIndex = topic.some(function(file) {
-                        return file === 'lcov.info';
+                    var self = this,
+                        _exit = util.exit;
+                    util.exit = function() {};
+                    process.chdir(__dirname);
+                    cleanReportDir();
+                    runTest('./html/istanbul.html', [
+                        '--coverdir',
+                        report
+                    ],function(err, json) {
+                        util.exit = _exit;
+                        self.callback(err, json);
                     });
-                    assert.isTrue(hasIndex);
                 },
-                'should have lcov-report': function (topic) {
-                    var hasIndex = topic.some(function(file) {
-                        return file === 'lcov-report';
-                    });
-                    assert.isTrue(hasIndex);
+                'and have suite name': function(json) {
+                    assert.equal(json.name, 'YQL');
                 },
-                'should have coverage json': function(topic) {
-                    var hasIndex = topic.some(function(file) {
-                        return file === 'coverage-final.json';
-                    });
-                    assert.isTrue(hasIndex);
+                'and should have 8 passing tests': function(json) {
+                    assert.equal(json.passed, 8);
+                },
+                'and should have 0 failed tests': function(json) {
+                    assert.equal(json.failed, 0);
+                },
+                'and should have report dirs': {
+                    topic: function() {
+                        return fs.readdirSync(report);
+                    },
+                    'should have lcov.info': function (topic) {
+                        var hasIndex = topic.some(function(file) {
+                            return file === 'lcov.info';
+                        });
+                        assert.isTrue(hasIndex);
+                    },
+                    'should have lcov-report': function (topic) {
+                        var hasIndex = topic.some(function(file) {
+                            return file === 'lcov-report';
+                        });
+                        assert.isTrue(hasIndex);
+                    },
+                    'should have coverage json': function(topic) {
+                        var hasIndex = topic.some(function(file) {
+                            return file === 'coverage-final.json';
+                        });
+                        assert.isTrue(hasIndex);
+                    }
                 }
             }
         }


### PR DESCRIPTION
For some use-cases - related to my day job :) -  I really really want the coverage output of grover to look like something generated out of `istanbul cover` (i.e. `lcov.info`, `lcov-report/` and `coverage.json`).

I added a `json` report format to istanbul and am using it in this PR to generate a JSON file when `coverdir` is specified. Please consider for merge.
