### PR TITLE
Fixed running tests on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Using the built in server
 -------------------------
 
 Using the `--server` command will fire up a server in the `process.cwd()` and serve anything
-under it as statis content. Then when you select the tests to be run, they are converted to URL's
+under it as static content. Then when you select the tests to be run, they are converted to URL's
 under the hood and fetched from the static server instead of the file system.
 
 Combine this with `-S` options like this:

--- a/lib/options.js
+++ b/lib/options.js
@@ -26,11 +26,11 @@ var path = require('path'),
         }, newPath, paths, a, p, t, v, concurrent, coverageFileName, sourceFilePrefix,
         phantom, stat,
         getPaths = function(opt) {
-            if (process.platform === 'win32' && !options.suffix) { //If options.suffix it's probably URL
+            if (process.platform === 'win32' && !options.suffix && !options.prefix && !options.server) { //If options.suffix it's probably a URL
                 var g = glob.sync(opt, {
                     cwd: process.cwd()
                 }).map(function (filepath) {
-                    return path.join(process.cwd(), filepath);
+                    return path.relative(process.cwd(), filepath); //phantomjs won't "request" relative resources for absolute Windows paths
                 });
                 if (g && g.length) {
                     options.paths = [].concat(options.paths, g);

--- a/tests/1-args.js
+++ b/tests/1-args.js
@@ -612,8 +612,8 @@ var tests = {
                 process.platform = _platform;
                 return ret;
             },
-            'should expand 7 paths': function(topic) {
-                assert.equal(topic.paths.length, 7);
+            'should expand 8 paths': function(topic) {
+                assert.equal(topic.paths.length, 8);
             }
         },
         'no files': {
@@ -626,6 +626,19 @@ var tests = {
             },
             'should expand 0 paths': function(topic) {
                 assert.equal(topic.paths.length, 0);
+            }
+        },
+        'files on Windows': {
+            topic: function() {
+                var _platform = process.platform, ret;
+                process.platform = 'win32';
+                ret = parse(['tests/html/relative.html', path.join(__dirname, '../tests/html/relative.html')]);
+                process.platform = _platform;
+                return ret;
+            },
+            'should return relative paths': function(topic) {
+                assert.equal(topic.paths[0], 'tests\\html\\relative.html')
+                assert.equal(topic.paths[1], 'tests\\html\\relative.html')
             }
         }
     }

--- a/tests/1-args.js
+++ b/tests/1-args.js
@@ -637,8 +637,8 @@ var tests = {
                 return ret;
             },
             'should return relative paths': function(topic) {
-                assert.equal(topic.paths[0], 'tests\\html\\relative.html');
-                assert.equal(topic.paths[1], 'tests\\html\\relative.html');
+                assert.equal(topic.paths[0], path.join('tests', 'html', 'relative.html'));
+                assert.equal(topic.paths[1], path.join('tests', 'html', 'relative.html'));
             }
         }
     }

--- a/tests/1-args.js
+++ b/tests/1-args.js
@@ -637,8 +637,8 @@ var tests = {
                 return ret;
             },
             'should return relative paths': function(topic) {
-                assert.equal(topic.paths[0], 'tests\\html\\relative.html')
-                assert.equal(topic.paths[1], 'tests\\html\\relative.html')
+                assert.equal(topic.paths[0], 'tests\\html\\relative.html');
+                assert.equal(topic.paths[1], 'tests\\html\\relative.html');
             }
         }
     }

--- a/tests/html/assets/relativetest.js
+++ b/tests/html/assets/relativetest.js
@@ -1,0 +1,1 @@
+relativeVar = true;

--- a/tests/html/relative.html
+++ b/tests/html/relative.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html>
+<head>
+    <title>Test One</title>
+</head>
+<body>
+<script src="http://yui.yahooapis.com/3.5.0/build/yui/yui-min.js"></script>
+<script src="./assets/relativetest.js"></script>
+<script>
+YUI().use('test', function(Y) {
+	var suite = new Y.Test.Suite('Relative Test');
+	suite.add(new Y.Test.Case({
+		name: 'relative',
+
+		'should be able to see relativeVar': function() {
+			Y.Assert.isTrue(relativeVar);
+		}
+	}));
+
+	Y.Test.Runner.add(suite).run();
+});
+</script>
+</body>
+</html>
+


### PR DESCRIPTION
I've had problems running tests on Windows that I've narrowed down to a simple test that includes a relative resource. For the `relative.html` test in this patch before applying my fixes in `options.js` I got the following results:

![paths-oh-my](https://f.cloud.github.com/assets/742941/914838/816e26fe-fe4e-11e2-97c3-12f51c1e80f5.png)

This patch fixes these problems (with tests) and also fixes the path resolution of tests to work correctly when using the `--prefix` and `--server` options (previously the tests for these were failing in the `1-args.js` test when run on Windows).

These changes supersede #2, which didn't correctly handle absolute paths.
