### PR TITLE
Fix a typo in the options usage text

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Commandline Arguments
     Coverage Options
        --coverage Generate a coverage report and print it to the screen (you must instrument your own files first)
        --coverage-warn <Number> The percentage to highlight as low coverage: default is 80
-       --istanbul-report <Path> Generate an Instabul coverage report into this directory
+       --istanbul-report <Path> Generate an Istanbul coverage report into this directory
        -co --coverageFileName <path to export coverage file> The coverage data in lcov format.
        -sp --sourceFilePrefix <path to sourcefile> The relative path to the original source file for use in the coverage results.
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -232,7 +232,7 @@ var path = require('path'),
                     log.log('Coverage Options');
                     log.log('   --coverage Generate a coverage report and print it to the screen (you must instrument your own files first)');
                     log.log('   --coverage-warn <Number> The percentage to highlight as low coverage: default is 80');
-                    log.log('   --istanbul-report <Path> Generate an Instabul coverage report into this directory');
+                    log.log('   --istanbul-report <Path> Generate an Istanbul coverage report into this directory');
                     log.log('   --coverdir <Path> generate a full lcov coverage report here');
                     log.log('   -co --coverageFileName <path to export coverage file> The coverage data in lcov format.');
                     log.log('   -sp --sourceFilePrefix <path to sourcefile> The relative path to the original source file for use in the coverage results.');


### PR DESCRIPTION
Just noticed a small typo in the `--help` :P
