### PR TITLE
Exit process only when 'fail' config is enabled

### DIFF
--- a/lib/grover.js
+++ b/lib/grover.js
@@ -222,7 +222,7 @@ exports.done = function(options, testResults, callback) {
         log.log('----------------------------------------------------------------');
         util.status(res, options.START, END);
     }
-    if (res.failed) {
+    if (options.exitOnFail && res.failed) {
         util.exit(1);
     }
     if (options.coverage) {


### PR DESCRIPTION
The issue is when another node module uses `grover` as a dependency, and if that module invokes `grover.process` method to run unit tests for a series of modules.
The grover.process command exits the node process as soon as there are test failures in any of the modules which prevents from running the unit tests report for subsequent modules. The node process should exit only when `fail` config is enabled by the user.

@caridy , @davglass . Please merge !!!
