### PR TITLE
Fix phantom args references for phantomjs 2.0.0+

### DIFF
--- a/lib/wrapper/wrapper.js
+++ b/lib/wrapper/wrapper.js
@@ -13,12 +13,13 @@ Timeout: Specify a timeout (override too) to kill a test
 var waitTimer,
     waitCounter = 0,
     testTimer,
-    file = phantom.args[0],
-    timeout = parseInt(phantom.args[1], 10),
+    phantomArgs = phantom.args || require('system').args.slice(1),
+    file = phantomArgs[0],
+    timeout = parseInt(phantomArgs[1], 10),
     timer,
     exited = false,
     debug = false, //Internal debugging of wrapper
-    logConsole = (phantom.args[2] === 'true' ? true : false),
+    logConsole = (phantomArgs[2] === 'true' ? true : false),
     log = function(a, b) {
         b = (typeof b === 'undefined') ? '' : b;
         if (debug) {
@@ -195,7 +196,7 @@ var executeTest = function(file, cb) {
 };
 
 
-if (!phantom.args.length) {
+if (!phantomArgs.length) {
     console.log('Please provide some test files to execute');
     phantom.exit(1);
 }


### PR DESCRIPTION
Maintain compatibility with phantomjs versions < 2.0.0
